### PR TITLE
Hotfix

### DIFF
--- a/app/models/parking_slot.py
+++ b/app/models/parking_slot.py
@@ -102,8 +102,8 @@ class ParkingSlot(Base):  # pylint: disable=too-few-public-methods
             "is_premium": self.is_premium,
             "slot_features": self.slot_features.value if self.slot_features else None,
             "base_price_per_hour": str(self.base_price_per_hour),
-            "base_rate_per_day": str(self.base_rate_per_day),
-            "base_rate_per_month": str(self.base_rate_per_month),
+            "base_price_per_day": str(self.base_price_per_day),
+            "base_price_per_month": str(self.base_price_per_month),
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/app/models/parking_slot.py
+++ b/app/models/parking_slot.py
@@ -59,8 +59,8 @@ class ParkingSlot(Base):  # pylint: disable=too-few-public-methods
     is_premium = Column(Boolean, nullable=False, default=False)
     slot_features = Column(ENUM(SlotFeature), nullable=False, default=SlotFeature.standard)
     base_price_per_hour = Column(Numeric(10, 2), nullable=False, default=0.00)
-    base_rate_per_day = Column(Numeric(10, 2), nullable=False, default=0.00)
-    base_rate_per_month = Column(Numeric(10, 2), nullable=False, default=0.00)
+    base_price_per_day = Column(Numeric(10, 2), nullable=False, default=0.00)
+    base_price_per_month = Column(Numeric(10, 2), nullable=False, default=0.00)
     price_multiplier = Column(Numeric(3, 2), nullable=False, default=1.00)
     created_at = Column(TIMESTAMP, default=func.current_timestamp())
     updated_at = Column(


### PR DESCRIPTION
This pull request includes changes to the `ParkingSlot` model in the `app/models/parking_slot.py` file to standardize the naming convention for price-related fields. The most important changes are:

* Renamed `base_rate_per_day` to `base_price_per_day` in the `ParkingSlot` model.
* Renamed `base_rate_per_month` to `base_price_per_month` in the `ParkingSlot` model.
* Updated the `to_dict` method to reflect the new field names `base_price_per_day` and `base_price_per_month`.